### PR TITLE
Fix DetalleVenta model fields

### DIFF
--- a/app/Models/DetalleVenta.php
+++ b/app/Models/DetalleVenta.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  * 
  * Este modelo representa el detalle de una venta en el sistema.
  * Cada detalle contiene información sobre un producto específico vendido,
- * incluyendo la cantidad, precio unitario y subtotal.
+ * incluyendo el nombre del producto, su precio, la cantidad y el subtotal.
  */
 class DetalleVenta extends Model
 {
@@ -23,9 +23,10 @@ class DetalleVenta extends Model
     protected $fillable = [
         'venta_id',
         'producto_id',
+        'producto_nombre',
+        'producto_precio',
         'cantidad',
-        'precio_unitario',
-        'subtotal',
+        'subTotal',
     ];
 
     /**

--- a/resources/js/pages/Reportes/Index.vue
+++ b/resources/js/pages/Reportes/Index.vue
@@ -48,5 +48,5 @@ const props = defineProps({
     required: true
   }
 });
-const contador=1;
+let contador = 1;
 </script>

--- a/resources/js/pages/Ventas/Show.vue
+++ b/resources/js/pages/Ventas/Show.vue
@@ -34,9 +34,13 @@
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
               <tr v-for="detalle in venta.detalles" :key="detalle.id">
-                <td class="px-6 py-4 whitespace-nowrap text-gray-900">{{ detalle.producto?.nombre }}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-gray-900">
+                  {{ detalle.producto ? detalle.producto.nombre : detalle.producto_nombre }}
+                </td>
                 <td class="px-6 py-4 whitespace-nowrap text-gray-900">{{ detalle.cantidad }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-gray-900">{{ detalle.producto_precio }} Bs</td>
+                <td class="px-6 py-4 whitespace-nowrap text-gray-900">
+                  {{ detalle.producto ? detalle.producto.precio : detalle.producto_precio }} Bs
+                </td>
                 <td class="px-6 py-4 whitespace-nowrap text-gray-900">{{ detalle.subTotal }} Bs</td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary
- align `DetalleVenta` model fillable fields with database columns so they persist correctly
- use local product data in sale details view when the relationship is missing

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca6236c48832dad7af0393f332ef9